### PR TITLE
Add test coverage requirements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run Tests and Coverage
 
 on:
   push:
@@ -22,7 +22,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install pytest-cov
         
-    - name: Run unit tests
+    - name: Run tests with coverage
       run: |
-        python -m pytest tests/unit/
+        python -m pytest tests/unit/ --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=80
+        
+    - name: Upload coverage reports
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: true


### PR DESCRIPTION
This PR adds test coverage requirements to the CI pipeline:

1. Adds pytest-cov for coverage reporting
2. Sets a minimum coverage threshold of 80%
3. Generates and uploads coverage reports to Codecov
4. Makes tests fail if coverage is below the threshold

After merging this PR, you should:
1. Go to repository Settings > Branches
2. Add a branch protection rule for the `development` branch
3. Enable "Require status checks to pass before merging"
4. Select the "Run Tests and Coverage" check as required