### PR TITLE
Add TXT record support

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -22,6 +22,11 @@ class ARecord(BaseModel):
     content: str
     ttl: Optional[int] = 3600
 
+class TXTRecord(BaseModel):
+    name: str
+    content: str
+    ttl: Optional[int] = 3600
+
 def get_db_connection():
     return mysql.connector.connect(
         host="localhost",
@@ -90,6 +95,78 @@ async def create_a_record(zone_name: str, record: ARecord):
             raise HTTPException(status_code=500, detail=f"PowerDNS API error: {str(e)}")
 
         return {"message": "A record created successfully"}
+
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
+@app.post("/api/v1/zones/{zone_name}/records/txt")
+async def create_txt_record(zone_name: str, record: TXTRecord):
+    conn = None
+    cursor = None
+    try:
+        if not zone_name.endswith('.'):
+            zone_name = zone_name + '.'
+            
+        conn = get_db_connection()
+        cursor = conn.cursor(dictionary=True)
+        
+        try:
+            # Check if zone exists
+            cursor.execute("SELECT id FROM domains WHERE name = %s", (zone_name,))
+            zone = cursor.fetchone()
+            
+            if not zone:
+                # Create zone
+                cursor.execute(
+                    "INSERT INTO domains (name, type) VALUES (%s, %s)",
+                    (zone_name, "NATIVE")
+                )
+                conn.commit()
+                zone_id = cursor.lastrowid
+            else:
+                zone_id = zone['id']
+                
+            # Create TXT record
+            record_name = record.name if record.name.endswith(f".{zone_name}") else f"{record.name}.{zone_name}"
+            
+            # Add quotes to content if it contains spaces and isn't already quoted
+            content = record.content
+            if ' ' in content and not (content.startswith('"') and content.endswith('"')):
+                content = f'"{content}"'
+            
+            cursor.execute(
+                "INSERT INTO records (domain_id, name, type, content, ttl) VALUES (%s, %s, %s, %s, %s)",
+                (zone_id, record_name, "TXT", content, record.ttl)
+            )
+            
+            conn.commit()
+
+        except mysql.connector.Error as e:
+            if conn:
+                conn.rollback()
+            raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")
+
+        # Notify PowerDNS of the change
+        try:
+            response = requests.put(
+                f"{PDNS_API_URL}/servers/localhost/zones/{zone_name}",
+                headers={"X-API-Key": PDNS_API_KEY},
+                json={"serial": 0}  # Force serial update
+            )
+
+            if response.status_code >= 400:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"PowerDNS API error: {response.text}"
+                )
+
+        except requests.exceptions.RequestException as e:
+            raise HTTPException(status_code=500, detail=f"PowerDNS API error: {str(e)}")
+
+        return {"message": "TXT record created successfully"}
 
     finally:
         if cursor:

--- a/tests/unit/test_txt_records.py
+++ b/tests/unit/test_txt_records.py
@@ -1,0 +1,134 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import Mock, patch
+import mysql.connector
+from src.app import app, get_db_connection
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+@pytest.fixture
+def mock_db_connection():
+    with patch('mysql.connector.connect') as mock_connect:
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connect.return_value = mock_conn
+        yield {
+            'connection': mock_conn,
+            'cursor': mock_cursor,
+            'connect': mock_connect
+        }
+
+@pytest.fixture
+def mock_requests():
+    with patch('requests.put') as mock_put:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_put.return_value = mock_response
+        yield mock_put
+
+def test_create_txt_record_new_zone(client, mock_db_connection, mock_requests):
+    # Setup mock database responses
+    mock_cursor = mock_db_connection['cursor']
+    mock_cursor.fetchone.return_value = None  # Zone doesn't exist
+    mock_cursor.lastrowid = 1  # New zone ID
+
+    # Test data
+    test_data = {
+        "name": "verification",
+        "content": "google-site-verification=abc123def456",
+        "ttl": 3600
+    }
+
+    # Make request
+    response = client.post("/api/v1/zones/example.com/records/txt", json=test_data)
+
+    # Assert response
+    assert response.status_code == 200
+    assert response.json() == {"message": "TXT record created successfully"}
+
+    # Verify database calls
+    mock_cursor.execute.assert_any_call(
+        "SELECT id FROM domains WHERE name = %s",
+        ("example.com.",)
+    )
+    mock_cursor.execute.assert_any_call(
+        "INSERT INTO domains (name, type) VALUES (%s, %s)",
+        ("example.com.", "NATIVE")
+    )
+    mock_cursor.execute.assert_any_call(
+        "INSERT INTO records (domain_id, name, type, content, ttl) VALUES (%s, %s, %s, %s, %s)",
+        (1, "verification.example.com.", "TXT", "google-site-verification=abc123def456", 3600)
+    )
+
+def test_create_txt_record_existing_zone(client, mock_db_connection, mock_requests):
+    # Setup mock database responses
+    mock_cursor = mock_db_connection['cursor']
+    mock_cursor.fetchone.return_value = {"id": 1}  # Zone exists
+
+    # Test data
+    test_data = {
+        "name": "spf",
+        "content": "v=spf1 include:_spf.example.com ~all",
+        "ttl": 3600
+    }
+
+    # Make request
+    response = client.post("/api/v1/zones/example.com/records/txt", json=test_data)
+
+    # Assert response
+    assert response.status_code == 200
+    assert response.json() == {"message": "TXT record created successfully"}
+
+    # Verify database calls
+    mock_cursor.execute.assert_any_call(
+        "SELECT id FROM domains WHERE name = %s",
+        ("example.com.",)
+    )
+    # Should not try to create zone
+    assert not any(
+        call[0][0].startswith("INSERT INTO domains")
+        for call in mock_cursor.execute.call_args_list
+    )
+    mock_cursor.execute.assert_any_call(
+        "INSERT INTO records (domain_id, name, type, content, ttl) VALUES (%s, %s, %s, %s, %s)",
+        (1, "spf.example.com.", "TXT", '"v=spf1 include:_spf.example.com ~all"', 3600)
+    )
+
+def test_create_txt_record_invalid_data(client):
+    # Test missing required field
+    test_data = {
+        "name": "spf",
+        # Missing content field
+        "ttl": 3600
+    }
+
+    response = client.post("/api/v1/zones/example.com/records/txt", json=test_data)
+    assert response.status_code == 422  # Validation error
+
+def test_create_txt_record_with_quotes(client, mock_db_connection, mock_requests):
+    # Setup mock database responses
+    mock_cursor = mock_db_connection['cursor']
+    mock_cursor.fetchone.return_value = {"id": 1}  # Zone exists
+
+    # Test data with content that should be quoted
+    test_data = {
+        "name": "test",
+        "content": "some text with spaces",
+        "ttl": 3600
+    }
+
+    # Make request
+    response = client.post("/api/v1/zones/example.com/records/txt", json=test_data)
+
+    # Assert response
+    assert response.status_code == 200
+    assert response.json() == {"message": "TXT record created successfully"}
+
+    # Verify database calls - content should be automatically quoted
+    mock_cursor.execute.assert_any_call(
+        "INSERT INTO records (domain_id, name, type, content, ttl) VALUES (%s, %s, %s, %s, %s)",
+        (1, "test.example.com.", "TXT", '"some text with spaces"', 3600)
+    )


### PR DESCRIPTION
This PR adds support for TXT records with the following features:

1. Create TXT records in new or existing zones
2. Automatic handling of quoted strings for TXT record content
3. Full test coverage including:
   - Creating TXT records in new zones
   - Creating TXT records in existing zones
   - Validation of required fields
   - Proper handling of quoted strings

The implementation follows the same pattern as A records but adds special handling for TXT record content formatting.