### PR TITLE
Fix deployment workflow to use appleboy/ssh-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,24 +23,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Create SSH key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/key.pem
-          chmod 600 ~/.ssh/key.pem
-          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
-
       - name: Deploy to EC2
-        run: |
-          # Create deployment script
-          echo '#!/bin/bash
-          cd ~/CitadelDNS || git clone https://github.com/juniorpayne/CitadelDNS.git ~/CitadelDNS
-          cd ~/CitadelDNS
-          git fetch origin
-          git reset --hard origin/main
-          pip3 install -r requirements.txt
-          sudo systemctl restart citadel-dns' > deploy.sh
-          
-          # Copy deployment script and execute
-          scp -i ~/.ssh/key.pem deploy.sh ubuntu@${{ secrets.EC2_HOST }}:~/deploy.sh
-          ssh -i ~/.ssh/key.pem ubuntu@${{ secrets.EC2_HOST }} "chmod +x ~/deploy.sh && ~/deploy.sh"
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd ~/CitadelDNS || git clone https://github.com/juniorpayne/CitadelDNS.git ~/CitadelDNS
+            cd ~/CitadelDNS
+            git fetch origin
+            git reset --hard origin/main
+            pip3 install -r requirements.txt
+            sudo systemctl restart citadel-dns


### PR DESCRIPTION
This PR fixes the deployment workflow by:

1. Removing manual SSH key handling
2. Using the appleboy/ssh-action GitHub Action for SSH operations
3. Simplifying the deployment process

This should resolve the SSH key creation issues in the current workflow.