### PR TITLE
Fix SSH action configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,14 @@ jobs:
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.0
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
         with:
-          host: ${{ secrets.EC2_HOST }}
+          host: ${{ env.EC2_HOST }}
           username: ubuntu
-          key: ${{ secrets.EC2_SSH_KEY }}
+          key: ${{ env.EC2_SSH_KEY }}
+          port: 22
           script: |
             cd ~/CitadelDNS || git clone https://github.com/juniorpayne/CitadelDNS.git ~/CitadelDNS
             cd ~/CitadelDNS


### PR DESCRIPTION
This PR fixes the SSH action configuration by:

1. Adding explicit environment variables for secrets
2. Adding explicit port configuration
3. Using environment variables in the SSH action configuration

This should resolve the "missing server host" error.