### PR TITLE
Use direct host value in SSH action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,13 +25,10 @@ jobs:
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.0
-        env:
-          EC2_HOST: ${{ secrets.EC2_HOST }}
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
         with:
-          host: ${{ env.EC2_HOST }}
+          host: 18.233.166.181
           username: ubuntu
-          key: ${{ env.EC2_SSH_KEY }}
+          key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           script: |
             cd ~/CitadelDNS || git clone https://github.com/juniorpayne/CitadelDNS.git ~/CitadelDNS


### PR DESCRIPTION
This PR simplifies the SSH action configuration by using the direct host value instead of secrets.