### PR TITLE
Fix PowerDNS repository setup

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -83,8 +83,16 @@ fi
 if ! command_exists pdns_server; then
     echo "Installing PowerDNS and MySQL backend..."
     # Add PowerDNS repository
-    curl https://repo.powerdns.com/FD380FBB-pub.asc | sudo apt-key add -
-    echo "deb [arch=amd64] http://repo.powerdns.com/ubuntu $(lsb_release -cs)-auth-master main" | \
+    curl -fsSL https://repo.powerdns.com/FD380FBB-pub.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pdns.gpg
+    curl -fsSL https://repo.powerdns.com/CBC8B383-pub.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pdns-master.gpg
+    
+    # Get Ubuntu codename and use jammy if noble is not yet supported
+    UBUNTU_CODENAME=$(lsb_release -cs)
+    if [ "$UBUNTU_CODENAME" = "noble" ]; then
+        UBUNTU_CODENAME="jammy"
+    fi
+    
+    echo "deb [arch=amd64] http://repo.powerdns.com/ubuntu ${UBUNTU_CODENAME}-auth-master main" | \
         sudo tee /etc/apt/sources.list.d/pdns.list
     sudo apt-get update
     


### PR DESCRIPTION
This PR fixes the PowerDNS repository setup by:

1. Using proper GPG key handling with gpg --dearmor
2. Adding both required GPG keys (FD380FBB and CBC8B383)
3. Handling Ubuntu Noble by using Jammy repository
4. Using -fsSL flags with curl for better error handling

This should resolve the GPG key error when adding the PowerDNS repository.